### PR TITLE
update load csv functions

### DIFF
--- a/regress/expected/age_load.out
+++ b/regress/expected/age_load.out
@@ -19,50 +19,26 @@
 \! cp -r regress/age_load/data regress/instance/data/age_load
 LOAD 'age';
 SET search_path TO ag_catalog;
-SELECT create_graph('agload_test_graph');
-NOTICE:  graph "agload_test_graph" has been created
- create_graph 
---------------
- 
-(1 row)
-
-SELECT create_vlabel('agload_test_graph','Country');
-NOTICE:  VLabel "Country" has been created
- create_vlabel 
----------------
- 
-(1 row)
-
 SELECT load_labels_from_file('agload_test_graph', 'Country',
     'age_load/countries.csv');
+NOTICE:  graph "agload_test_graph" has been created
+NOTICE:  VLabel "Country" has been created
  load_labels_from_file 
 -----------------------
- 
-(1 row)
-
-SELECT create_vlabel('agload_test_graph','City');
-NOTICE:  VLabel "City" has been created
- create_vlabel 
----------------
  
 (1 row)
 
 SELECT load_labels_from_file('agload_test_graph', 'City',
     'age_load/cities.csv');
+NOTICE:  VLabel "City" has been created
  load_labels_from_file 
 -----------------------
  
 (1 row)
 
-SELECT create_elabel('agload_test_graph','has_city');
-NOTICE:  ELabel "has_city" has been created
- create_elabel 
----------------
- 
-(1 row)
-
 SELECT load_edges_from_file('agload_test_graph', 'has_city',
      'age_load/edges.csv');
+NOTICE:  ELabel "has_city" has been created
  load_edges_from_file 
 ----------------------
  
@@ -110,29 +86,17 @@ SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$
  72485
 (1 row)
 
-SELECT create_vlabel('agload_test_graph','Country2');
-NOTICE:  VLabel "Country2" has been created
- create_vlabel 
----------------
- 
-(1 row)
-
 SELECT load_labels_from_file('agload_test_graph', 'Country2',
                              'age_load/countries.csv', false);
+NOTICE:  VLabel "Country2" has been created
  load_labels_from_file 
 -----------------------
  
 (1 row)
 
-SELECT create_vlabel('agload_test_graph','City2');
-NOTICE:  VLabel "City2" has been created
- create_vlabel 
----------------
- 
-(1 row)
-
 SELECT load_labels_from_file('agload_test_graph', 'City2',
                              'age_load/cities.csv', false);
+NOTICE:  VLabel "City2" has been created
  load_labels_from_file 
 -----------------------
  

--- a/regress/sql/age_load.sql
+++ b/regress/sql/age_load.sql
@@ -22,17 +22,13 @@
 LOAD 'age';
 
 SET search_path TO ag_catalog;
-SELECT create_graph('agload_test_graph');
 
-SELECT create_vlabel('agload_test_graph','Country');
 SELECT load_labels_from_file('agload_test_graph', 'Country',
     'age_load/countries.csv');
 
-SELECT create_vlabel('agload_test_graph','City');
 SELECT load_labels_from_file('agload_test_graph', 'City',
     'age_load/cities.csv');
 
-SELECT create_elabel('agload_test_graph','has_city');
 SELECT load_edges_from_file('agload_test_graph', 'has_city',
      'age_load/edges.csv');
 
@@ -48,11 +44,9 @@ SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH(n) RETURN n$$) as (n ag
 
 SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$) as (n agtype);
 
-SELECT create_vlabel('agload_test_graph','Country2');
 SELECT load_labels_from_file('agload_test_graph', 'Country2',
                              'age_load/countries.csv', false);
 
-SELECT create_vlabel('agload_test_graph','City2');
 SELECT load_labels_from_file('agload_test_graph', 'City2',
                              'age_load/cities.csv', false);
 

--- a/src/backend/utils/load/age_load.c
+++ b/src/backend/utils/load/age_load.c
@@ -30,6 +30,7 @@
 
 #include "catalog/ag_graph.h"
 #include "catalog/ag_label.h"
+#include "commands/graph_commands.h"
 #include "utils/agtype.h"
 #include "utils/graphid.h"
 
@@ -247,12 +248,24 @@ Datum load_labels_from_file(PG_FUNCTION_ARGS)
     file_path = PG_GETARG_TEXT_P(2);
     id_field_exists = PG_GETARG_BOOL(3);
 
-
     graph_name_str = NameStr(*graph_name);
     label_name_str = NameStr(*label_name);
     file_path_str = text_to_cstring(file_path);
 
+    if (!graph_exists(graph_name_str))
+    {
+        DirectFunctionCall1(create_graph, CStringGetDatum(graph_name_str));
+    }
+
     graph_oid = get_graph_oid(graph_name_str);
+
+    if (!label_exists(label_name_str, graph_oid))
+    {
+        DirectFunctionCall2(create_vlabel, 
+                            CStringGetDatum(graph_name_str), 
+                            CStringGetDatum(label_name_str));
+    }
+
     label_id = get_label_id(label_name_str, graph_oid);
 
     create_labels_from_csv_file(file_path_str, graph_name_str, graph_oid,
@@ -300,7 +313,19 @@ Datum load_edges_from_file(PG_FUNCTION_ARGS)
     label_name_str = NameStr(*label_name);
     file_path_str = text_to_cstring(file_path);
 
+    if (!graph_exists(graph_name_str))
+    {
+        DirectFunctionCall1(create_graph, CStringGetDatum(graph_name_str));
+    }
+
     graph_oid = get_graph_oid(graph_name_str);
+
+    if (!label_exists(label_name_str, graph_oid))
+    {
+        DirectFunctionCall2(create_elabel, 
+                            CStringGetDatum(graph_name_str), 
+                            CStringGetDatum(label_name_str));
+    }
     label_id = get_label_id(label_name_str, graph_oid);
 
     create_edges_from_csv_file(file_path_str, graph_name_str, graph_oid,


### PR DESCRIPTION
`load_labels_from_file` and `load_edges_from_file` now checks if there's already a graph and label with the provided name and creates it if there isn't. So it won't need to issue `SELECT create_graph();` and `SELECT create_vlabel();` with these functions calls.

Importing csv files **before**:

```sql
SELECT create_graph('agload');
SELECT create_vlabel('agload','Country');
SELECT load_labels_from_file('agload', 'Country', '/countries.csv');

SELECT create_elabel('agload','has_city');
SELECT load_edges_from_file('agload', 'has_city', 'edges.csv');
```

Importing csv files **after** proposed changes:

```sql
SELECT load_labels_from_file('agload_test_graph', 'Country', 'age_load/countries.csv');
NOTICE:  graph "agload_test_graph" has been created
NOTICE:  VLabel "Country" has been created
 load_labels_from_file 
-----------------------
 
(1 row)

SELECT load_edges_from_file('agload_test_graph', 'has_city', 'age_load/edges.csv');
NOTICE:  ELabel "has_city" has been created
 load_edges_from_file 
----------------------
 
(1 row)
```

These proposed changes may improve user experience by increasing automation and requiring less commands for the same task, also decreasing error chances of wrong issued commands.
